### PR TITLE
Additional SVG animation examples

### DIFF
--- a/examples/svg/accumulate-from-to.svg
+++ b/examples/svg/accumulate-from-to.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <rect x="0" y="0" width="100" height="100" fill="green">
+    <!-- reverts to width 100 after 4 seconds -->
+    <animate attributeName="width" from="200" to="100" dur="1s" repeatCount="4" accumulate="sum"/>
+  </rect>
+  <rect x="0" y="110" width="100" height="10" fill="blue"/>
+  <rect x="0" y="120" width="200" height="10" fill="blue"/>
+  <rect x="0" y="130" width="300" height="10" fill="blue"/>
+  <rect x="0" y="140" width="400" height="10" fill="blue"/>
+  <rect x="0" y="150" width="500" height="10" fill="blue"/>
+</svg>

--- a/examples/svg/additive.svg
+++ b/examples/svg/additive.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="400">
+  <rect x="0" y="0" width="100" height="100" fill="green">
+
+   <animateMotion values="0,0 ; 0,200" dur="5s"/>
+   <animateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+
+  </rect>
+</svg>

--- a/examples/svg/animateMotion-bezier.svg
+++ b/examples/svg/animateMotion-bezier.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="800">
+  <rect width="40" height="20" fill="lime">
+    <animateMotion calcMode="paced" path="M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700"
+      dur="5s" repeatCount="indefinite" rotate="auto"/>
+  </rect>
+</svg>

--- a/examples/svg/end.svg
+++ b/examples/svg/end.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <rect x="0" y="0" width="100" height="100" fill="green">
+    <!-- to is ignored as there is no duration -->
+    <animate attributeName="width" from="300" to="0" end="2s"/>
+  </rect>
+</svg>

--- a/examples/svg/freeze.svg
+++ b/examples/svg/freeze.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+  <rect x="100" y="100" width="100" height="100" fill="green">
+    <animate attributeName="x" from="100" to="200" dur="2s" fill="freeze"/>
+    <animate attributeName="height" from="100" to="200" dur="2s" fill="freeze"/>
+    <animate attributeName="width" from="100" to="200" begin="2s" dur="2s" fill="freeze"/>
+  </rect>
+</svg>

--- a/examples/svg/implicit-discrete.svg
+++ b/examples/svg/implicit-discrete.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="400" height="400">
+  <polyline points="200 200 200 300 300 300" stroke="blue" stroke-width="190" stroke-linecap="square" stroke-linejoin="bevel">
+    <animate attributeName="stroke-linejoin" from="miter" to="round" dur="4s"/>
+  </polyline>
+</svg>

--- a/examples/svg/keySplines.svg
+++ b/examples/svg/keySplines.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="900" height="100">
+  <rect x="0" y="0" width="0" height="100" fill="green">
+    <!-- keyTimes is implicitly "0; 0.5; 1" -->
+    <animate attributeName="width" values="0; 800; 0" calcMode="spline" keySplines="0 .75 .25 1; 0.75, 0, 1, 0.25" begin="1s" dur="3s"/>
+  </rect>
+</svg>

--- a/examples/svg/nested.svg
+++ b/examples/svg/nested.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="200">
+  <rect x="100" y="0" width="100" height="100" fill="green">
+    <animate attributeName="x" from="700" to="100" dur="6s" fill="freeze"/>
+    <animate attributeName="x" additive="replace" accumulate="sum" from="200" to="300" begin="1s" dur="2s" repeatCount="2"/>
+  </rect>
+
+  <rect x="100" y="110" width="100" height="10" fill="blue"/>
+  <rect x="100" y="120" width="200" height="10" fill="blue"/>
+  <rect x="100" y="130" width="300" height="10" fill="blue"/>
+  <rect x="100" y="140" width="400" height="10" fill="blue"/>
+  <rect x="100" y="150" width="500" height="10" fill="blue"/>
+  <rect x="100" y="160" width="600" height="10" fill="blue"/>
+  <rect x="100" y="170" width="700" height="10" fill="blue"/>
+  <rect x="100" y="180" width="800" height="10" fill="blue"/>
+  <rect x="100" y="190" width="900" height="10" fill="blue"/>
+</svg>

--- a/examples/web/accumulate-from-to.html
+++ b/examples/web/accumulate-from-to.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="600" height="200">
+      <rect id="element" x="0" y="0" width="100" height="100" fill="green"/>
+      <rect x="0" y="110" width="100" height="10" fill="blue"/>
+      <rect x="0" y="120" width="200" height="10" fill="blue"/>
+      <rect x="0" y="130" width="300" height="10" fill="blue"/>
+      <rect x="0" y="140" width="400" height="10" fill="blue"/>
+      <rect x="0" y="150" width="500" height="10" fill="blue"/>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      var keyframes = [
+        { width: '200px', offset: 0 },
+        { width: '100px', offset: 0.25 },
+        { width: '300px', offset: 0.25 },
+        { width: '200px', offset: 0.5 },
+        { width: '400px', offset: 0.5 },
+        { width: '300px', offset: 0.75 },
+        { width: '500px', offset: 0.75 },
+        { width: '400px', offset: 1 },
+      ];
+      element.animate(keyframes, {duration: 4000});
+    </script>
+  </body>
+</html>

--- a/examples/web/additive.html
+++ b/examples/web/additive.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="300" height="400">
+      <rect id="element" x="0" y="0" width="100" height="100" fill="green">
+      </rect>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+
+      element.animate([
+        {transform: 'translate(0px, 0px)'},
+        {transform: 'translate(10px, 10px)'},
+        {transform: 'translate(0px, 40px)'},
+        {transform: 'translate(10px, 50px)'},
+        {transform: 'translate(0px, 80px)'},
+        {transform: 'translate(10px, 90px)'},
+        {transform: 'translate(0px, 120px)'},
+        {transform: 'translate(10px, 130px)'},
+        {transform: 'translate(0px, 160px)'},
+        {transform: 'translate(10px, 170px)'},
+        {transform: 'translate(0px, 200px)'},
+      ], {duration: 5000}); 
+
+    </script>
+  </body>
+</html>

--- a/examples/web/animateMotion-bezier.html
+++ b/examples/web/animateMotion-bezier.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="800" height="800">
+      <rect id="element" width="40" height="20" fill="lime">
+      </rect>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      var effect = new MotionPathEffect('M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700', 'auto-rotate');
+      element.animate(effect, {duration: 5000, iterations: Infinity});
+    </script>
+  </body>
+</html>

--- a/examples/web/end.html
+++ b/examples/web/end.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg>
+      <rect id="element" x="0" y="0" width="100" height="100" fill="green">
+      </rect>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      element.animate([{width: '300'}, {width: '300'}], {duration: 2000, fill: 'none'});
+    </script>
+  </body>
+</html>

--- a/examples/web/freeze.html
+++ b/examples/web/freeze.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="600" height="600">
+      <rect id="element" x="100" y="100" width="100" height="100" fill="green">
+      </rect>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      element.animate([{x: '100'}, {x: '200'}], {duration: 2000, fill: 'forwards'});
+      // This height animation is being ignored - due to a Polyfill bug?
+      element.animate([{height: '100'}, {height: '200'}], {duration: 2000, fill: 'forwards'});
+      element.animate([{width: '100'}, {width: '200'}], {delay: 2000, duration: 2000, fill: 'forwards'});
+    </script>
+  </body>
+</html>

--- a/examples/web/implicit-discrete.html
+++ b/examples/web/implicit-discrete.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="400" height="400">
+      <polyline id="element" points="200 200 200 300 300 300" stroke="blue" stroke-width="190" stroke-linecap="square" stroke-linejoin="bevel"/>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      
+      var keyframes = [
+        {strokeLinejoin: 'miter'}, // setting keyframes[0]['stroke-linejoin'] also works
+        {strokeLinejoin: 'round'}
+      ];
+      element.animate(keyframes, {duration: 4000});
+    </script>
+  </body>
+</html>

--- a/examples/web/keySplines.html
+++ b/examples/web/keySplines.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="900" height="100">
+      <rect id="element" x="0" y="0" width="0" height="100" fill="green">
+      </rect>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      // offsets are implicitly 0, 0.5, 1
+      var keyframes = [
+        {width: '0', easing: 'cubic-bezier(0 .75 .25 1)'},
+        {width: '800', easing: 'cubic-bezier(0.75, 0, 1, 0.25)'},
+        {width: '0'}
+      ];
+      element.animate(keyframes, {duration: 3000, delay: 1000});
+    </script>
+  </body>
+</html>

--- a/examples/web/nested.html
+++ b/examples/web/nested.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="800" height="200">
+      <rect id="element" x="100" y="0" width="100" height="100" fill="green"/>
+
+      <rect x="100" y="110" width="100" height="10" fill="blue"/>
+      <rect x="100" y="120" width="200" height="10" fill="blue"/>
+      <rect x="100" y="130" width="300" height="10" fill="blue"/>
+      <rect x="100" y="140" width="400" height="10" fill="blue"/>
+      <rect x="100" y="150" width="500" height="10" fill="blue"/>
+      <rect x="100" y="160" width="600" height="10" fill="blue"/>
+      <rect x="100" y="170" width="700" height="10" fill="blue"/>
+      <rect x="100" y="180" width="800" height="10" fill="blue"/>
+      <rect x="100" y="190" width="900" height="10" fill="blue"/>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      var keyframes = [
+        {x: 700, offset: 0.0/6},
+        {x: 600, offset: 1.0/6},
+        {x: 200, offset: 1.0/6},
+        {x: 300, offset: 3.0/6},
+        {x: 500, offset: 3.0/6},
+        {x: 600, offset: 5.0/6},
+        {x: 200, offset: 5.0/6},
+        {x: 100, offset: 6.0/6},
+      ];
+      element.animate(keyframes, {duration: 6000, fill: 'forwards'});
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
keySplines shows how Beziers can be used for timing.

animateMotion-bezier shows how Beziers can be used in motion paths.

implicit-discrete shows how we jump when the property does not support
smooth interpolation.
