### PR TITLE
Animate height and circle coordinates.

### DIFF
--- a/examples/svg/circle.svg
+++ b/examples/svg/circle.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+  <circle id="element" cx="20" cy="20" r="10" fill="green">
+    <animate attributeName="cx" from="300" to="200" dur="4s" fill="freeze"/>
+    <animate attributeName="cy" from="300" to="200" dur="4s" fill="freeze"/>
+    <animate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
+  </circle>
+</svg>

--- a/examples/web-animations.js
+++ b/examples/web-animations.js
@@ -4569,6 +4569,7 @@ var propertyTypes = {
   clip: typeWithKeywords(['auto'], rectangleType),
   color: colorType,
   cx: lengthType,
+  cy: lengthType,
 
   // TODO: Handle these keywords properly.
   fontSize: typeWithKeywords(['smaller', 'larger'], percentLengthType),
@@ -4604,6 +4605,7 @@ var propertyTypes = {
   paddingTop: lengthType,
   perspective: typeWithKeywords(['none'], lengthType),
   perspectiveOrigin: originType,
+  r: lengthType,
   right: percentLengthAutoType,
   textIndent: typeWithKeywords(['each-line', 'hanging'], percentLengthType),
   textShadow: shadowType,
@@ -4638,6 +4640,9 @@ var propertyTypes = {
 
 var svgProperties = {
   'cx': 1,
+  'cy': 1,
+  'height': 1,
+  'r': 1,
   'width': 1,
   'x': 1,
   'y': 1

--- a/examples/web/circle.html
+++ b/examples/web/circle.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <svg width="600" height="600">
+      <circle id="element" cx="20" cy="20" r="10" fill="green"/>
+    </svg>
+    <script src="../web-animations.js"></script>
+    <script>
+      'use strict';
+      var element = document.getElementById('element');
+      element.animate([{cx: '300', cy: '300', r: '200'}, {cx: '200', cy: '200', r: '100'}], {duration: 4000, fill: 'forwards'});
+    </script>
+  </body>
+</html>

--- a/examples/web/freeze.html
+++ b/examples/web/freeze.html
@@ -10,7 +10,6 @@
       'use strict';
       var element = document.getElementById('element');
       element.animate([{x: '100'}, {x: '200'}], {duration: 2000, fill: 'forwards'});
-      // This height animation is being ignored - due to a Polyfill bug?
       element.animate([{height: '100'}, {height: '200'}], {duration: 2000, fill: 'forwards'});
       element.animate([{width: '100'}, {width: '200'}], {delay: 2000, duration: 2000, fill: 'forwards'});
     </script>


### PR DESCRIPTION
Note that these tests required a Polyfill bug fix to run correctly:
https://github.com/web-animations/web-animations-js/pull/602
