### PR TITLE
Declare character encoding in generated index

### DIFF
--- a/examples/compare.html
+++ b/examples/compare.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
-  <header>
+  <head>
+    <meta charset="UTF-8" />
     <style>
       #display {
         height: 500px;
@@ -19,7 +20,7 @@
       }
     </style>
     <script src="populate.js"></script>
-  </header>
+  </head>
   <body>
     <div id="display">
       <iframe id="display_svg"></iframe>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <header>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
   <body>
     <ul>
       

--- a/examples/template-index.html
+++ b/examples/template-index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <header>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
   <body>
     <ul>
       {% for item in examples %}


### PR DESCRIPTION
Specify the character encoding within a head tag.

This avoids warnings when viewing in Firefox.
