### PR TITLE
Paced timing using additional keyframes.

### DIFF
--- a/examples/svg/discrete.svg
+++ b/examples/svg/discrete.svg
@@ -2,6 +2,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <rect x="0" y="0" width="100" height="100" fill="green">
-    <animate attributeName="width" values="100;10;50;10;100" calcMode="discrete" dur="2s" repeatCount="2"/>
+    <animate attributeName="width" values="100;10;50;10;100" calcMode="discrete" dur="5s" repeatCount="2"/>
   </rect>
 </svg>

--- a/examples/web/discrete.html
+++ b/examples/web/discrete.html
@@ -10,13 +10,18 @@
       'use strict';
       var element = document.getElementById('element');
       var keyframes = [
-        {width: '100'},
-        {width: '10'},
-        {width: '50'},
-        {width: '10'},
-        {width: '100'}
+        {width: '100', offset:0},
+        {width: '100', offset:0.2},
+        {width: '10', offset:0.2},
+        {width: '10', offset:0.4},
+        {width: '50', offset:0.4},
+        {width: '50', offset:0.6},
+        {width: '10', offset:0.6},
+        {width: '10', offset:0.8},
+        {width: '100', offset:0.8},
+        {width: '100', offset:1}
       ];
-      element.animate(keyframes, {duration: 2000, iterations: 2, easing: 'steps(4, end)'});
+      element.animate(keyframes, {duration: 5000, iterations: 2});
     </script>
   </body>
 </html>


### PR DESCRIPTION
When animating between 5 values using calcMode="discrete", each value
should be used for 1/5 of the animation duration.

This can be achieved by passing 10 keyframes with explicit offsets to Web Animations.

We were previously using 5 keyframes without offsets, and using
easing: 'steps(4, end)'

This did not achieve accurate timing.
